### PR TITLE
Implement acceptsUserInputOnTrack

### DIFF
--- a/TOScrollBar/TOScrollBar.h
+++ b/TOScrollBar/TOScrollBar.h
@@ -65,6 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The scroll view in which this scroll bar has been added. */
 @property (nonatomic, weak, readonly) UIScrollView *scrollView;
 
+/** Whether the track responds to user input. Defaults to true. */
+@property (nonatomic) BOOL acceptsUserInputOnTrack;
+
 /** 
  Creates a new instance of the scroll bar view 
  

--- a/TOScrollBar/TOScrollBar.m
+++ b/TOScrollBar/TOScrollBar.m
@@ -491,6 +491,17 @@ typedef struct TOScrollBarScrollViewState TOScrollBarScrollViewState;
     self.dragging = NO;
 }
 
+-(BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+	if (self.acceptsUserInputOnTrack) {
+		return [super pointInside:point withEvent:event];
+	} else {
+		CGFloat handleMinY = CGRectGetMinY(self.handleView.frame);
+		CGFloat handleMaxY = CGRectGetMaxY(self.handleView.frame);
+		
+		return (0 <= point.x) && (handleMinY <= point.y) && (point.y <= handleMaxY);
+	}
+}
+
 - (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     UIView *result = [super hitTest:point withEvent:event];


### PR DESCRIPTION
When the track touch area (not the painted area) overlaps buttons available in the UIScrollView, it's advantageous to maintain the utility of manipulating the handle directly, but not to accept input on the track itself. 