### PR TITLE
Add exclusive setting for handle UI element

### DIFF
--- a/TOScrollBar/TOScrollBar.h
+++ b/TOScrollBar/TOScrollBar.h
@@ -65,6 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The scroll view in which this scroll bar has been added. */
 @property (nonatomic, weak, readonly) UIScrollView *scrollView;
 
+/** Whether the track responds to user input. Defaults to true. */
+@property (nonatomic) BOOL acceptsUserInputOnTrack;
+
 /** 
  Creates a new instance of the scroll bar view 
  

--- a/TOScrollBar/TOScrollBar.h
+++ b/TOScrollBar/TOScrollBar.h
@@ -69,8 +69,10 @@ NS_ASSUME_NONNULL_BEGIN
 /** The scroll view in which this scroll bar has been added. */
 @property (nonatomic, weak, readonly) UIScrollView *scrollView;
 
-/** Whether the track responds to user input. Defaults to true. */
-@property (nonatomic) BOOL acceptsUserInputOnTrack;
+/** When enabled, the scroll bar will only respond to direct touches to the handle control.
+ Touches to the track will be passed to the UI controls beneath it.
+ Default is NO. */
+@property (nonatomic, assign) BOOL handleExclusiveInteractionEnabled;
 
 /** 
  Creates a new instance of the scroll bar view 

--- a/TOScrollBar/TOScrollBar.m
+++ b/TOScrollBar/TOScrollBar.m
@@ -491,6 +491,17 @@ typedef struct TOScrollBarScrollViewState TOScrollBarScrollViewState;
     self.dragging = NO;
 }
 
+-(BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+	if (self.acceptsUserInputOnTrack) {
+		return [super pointInside:point withEvent:event];
+	} else {
+		CGFloat handleMinY = CGRectGetMinY(self.handleView.frame);
+		CGFloat handleMaxY = CGRectGetMaxY(self.handleView.frame);
+		
+		return (0 <= point.x) && (handleMinY <= point.y) && (point.y <= handleMaxY);
+	}
+}
+
 - (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     UIView *result = [super hitTest:point withEvent:event];

--- a/TOScrollBar/TOScrollBar.m
+++ b/TOScrollBar/TOScrollBar.m
@@ -120,7 +120,6 @@ typedef struct TOScrollBarScrollViewState TOScrollBarScrollViewState;
     _minimumContentHeightScale = kTOScrollBarMinimumContentScale;
     _verticalInset = UIEdgeInsetsMake(kTOScrollBarVerticalPadding, 0.0f, kTOScrollBarVerticalPadding, 0.0f);
     _feedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
-	_acceptsUserInputOnTrack = YES;
 }
 
 - (void)setUpViews
@@ -456,7 +455,7 @@ typedef struct TOScrollBarScrollViewState TOScrollBarScrollViewState;
         return;
     }
 
-	if (self.acceptsUserInputOnTrack) {
+	if (!self.handleExclusiveInteractionEnabled) {
 		// User tapped somewhere else, animate the handle to that point
 		CGFloat halfHeight = (handleFrame.size.height * 0.5f);
 
@@ -493,7 +492,7 @@ typedef struct TOScrollBarScrollViewState TOScrollBarScrollViewState;
     CGFloat minimumY = 0.0f;
     CGFloat maximumY = trackFrame.size.height - handleFrame.size.height;
 
-	if (!self.acceptsUserInputOnTrack) {
+	if (self.handleExclusiveInteractionEnabled) {
 		if (touchPoint.y < (handleFrame.origin.y - 20) ||
 			touchPoint.y > handleFrame.origin.y + (handleFrame.size.height + 20))
 		{
@@ -558,10 +557,12 @@ typedef struct TOScrollBarScrollViewState TOScrollBarScrollViewState;
     } completion:nil];
 }
 
--(BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-	if (self.acceptsUserInputOnTrack) {
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
+	
+    if (!self.handleExclusiveInteractionEnabled) {
 		return [super pointInside:point withEvent:event];
-	} else {
+	}
+    else {
 		CGFloat handleMinY = CGRectGetMinY(self.handleView.frame);
 		CGFloat handleMaxY = CGRectGetMaxY(self.handleView.frame);
 		

--- a/TOScrollBar/TOScrollBar.m
+++ b/TOScrollBar/TOScrollBar.m
@@ -557,20 +557,19 @@ typedef struct TOScrollBarScrollViewState TOScrollBarScrollViewState;
     } completion:nil];
 }
 
-- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event {
-	
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
+{
     if (!self.handleExclusiveInteractionEnabled) {
 		return [super pointInside:point withEvent:event];
 	}
     else {
 		CGFloat handleMinY = CGRectGetMinY(self.handleView.frame);
 		CGFloat handleMaxY = CGRectGetMaxY(self.handleView.frame);
-		
 		return (0 <= point.x) && (handleMinY <= point.y) && (point.y <= handleMaxY);
 	}
 }
 
-- (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     UIView *result = [super hitTest:point withEvent:event];
 


### PR DESCRIPTION
Thanks again for the PR @lynchrb!

I cleaned it up a little bit though. :) I renamed it to `handleExclusiveInteractionEnabled` to make it more in-line with Cocoa Touch naming conventions and turned it off by default (I need that functionality in my app).